### PR TITLE
Fixed linter compilation errors for missing files

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,10 +1,10 @@
 name: linter-review
 
 on: 
-    pull_request:
-        paths:
-            - "engine/**.cpp"
-            - "engine/**.hpp"
+  pull_request:
+      paths:
+          - "engine/**.cpp"
+          - "engine/**.hpp"
 
 jobs:
   clangtidy:
@@ -12,15 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Create dummy folders
-      run: 'mkdir GL glm glm/gtc'
-      shell: bash
-
-    # Create dummy files for missing files that cause compile errors
-    - name: Create dummy files
-      run: 'echo "" | tee -a Windows.h GL/glew.h glm/glm.hpp glm/gtc/matrix_transform.hpp SDL.h'
-      shell: bash
 
     - uses: ZedThree/clang-tidy-review@v0.14.0
       id: review
@@ -50,6 +41,7 @@ jobs:
                 glhf
         
             
+        include: 'engine/*.[ch]pp'
         config_file: '.clang-tidy'
 
     # If there are any comments, fail the check

--- a/engine/DisplayTerminal.hpp
+++ b/engine/DisplayTerminal.hpp
@@ -22,7 +22,7 @@ namespace engine {
 		bool operator < (const Point& point) const
 		{
 			return (y < point.y) || (!(point.y < y) && x < point.x);
-		}
+		} 
 	};
 
 	struct DisplayContent {


### PR DESCRIPTION
* Fixed linter erroring with `clang-diagnostic-error` due to missing files